### PR TITLE
Clean ground eps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-06-14
+
+### Fixed
+
+- Fixed a bug in clean_ground(). It caused that, during denoising step before dtm computation, the removed points (noise) were independent of the voxel resolution used.
+
 ## [0.2.0] - 2023-06-02
 
 ### Added

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -41,7 +41,8 @@ def clean_ground(cloud, res_ground=0.15, min_points=2):
     )
     # Cluster labels are appended to the FILTERED cloud. They map each point to
     # the cluster they belong to, according to the clustering algorithm.
-    clustering = DBSCAN(eps=0.3, min_samples=min_points).fit(vox_cloud)
+    eps = res_ground * 1.75
+    clustering = DBSCAN(eps=eps, min_samples=min_points).fit(vox_cloud)
 
     cloud_labs = np.append(
         cloud, np.expand_dims(clustering.labels_[vox_to_cloud_ind], axis=1), axis=1


### PR DESCRIPTION
Fixed `clean_ground` behaviour when res_ground is modified. 
*Before: DBSCAN eps would not change accordingly.
*Now: DBSCAN eps adapts to new resolution.