### PR TITLE
Normalization checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added clearer error messages in certain situations where point density of input point cloud was low and no clusters were found in step "1.-Extracting the stripe and peeling the stems". Previous error messages were Python's defaults "zero-size array to reduction operation minimum which has no identity" and "min() arg is an empty sequence".
 
+- Added `ground.check_normalization`. This function slices a normalized point cloud and compares its area vs. a scalar. It's intended use it's to compare the area of a point cloud to the area of a slice of points around ground level from the height-normalized version of the same point cloud. This is useful to check for inconsistencies in the height-normalization.
+
 ## [0.2.1] - 2023-07-10
 
 ### Fixed

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -243,7 +243,7 @@ def check_normalization(cloud, n_digits, original_area, z_min=-0.1, z_max=0.1):
         The minimum Z value that defines the slice. Defaults to -0.1.
     z_max: float
         The maximum Z value that defines the slice. Defaults to 0.1.
-    
+
     Returns
     -------
     area_warning : bool
@@ -254,12 +254,12 @@ def check_normalization(cloud, n_digits, original_area, z_min=-0.1, z_max=0.1):
 
     # Voxelate the slice and store only cloud_to_vox_ind output for efficiency
     _, _, voxelated_slice = dm.voxelate(
-                ground_slice, 1, 2000, n_digits = n_digits, with_n_points=False, silent=False
-            )
-    
+        ground_slice, 1, 2000, n_digits=n_digits, with_n_points=False, silent=False
+    )
+
     # Area of the voxelated ground slice (number of 1 m2 voxels)
     slice_area = voxelated_slice.shape[0]
-    
+
     # Calculate 10 % of the original area
     ten_percent_of_area = 0.1 * abs(original_area)
 
@@ -273,4 +273,3 @@ def check_normalization(cloud, n_digits, original_area, z_min=-0.1, z_max=0.1):
         area_warning = False
 
     return area_warning
-    

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -227,7 +227,9 @@ def normalize_heights(cloud, dtm_points):
 # -----------------------------------------------------------------------------
 
 
-def check_normalization(cloud, original_area, res_xy = 0.5, z_min=-0.1, z_max=0.1, warning_thresh = 0.1):
+def check_normalization(
+    cloud, original_area, res_xy=0.5, z_min=-0.1, z_max=0.1, warning_thresh=0.1
+):
     """Compare the area of a slice of points from a point cloud to another area and
     store a warning indicator if difference is greater than a certain threshold. Area
     of the slice will be approximated from a voxelated version of it.
@@ -255,13 +257,9 @@ def check_normalization(cloud, original_area, res_xy = 0.5, z_min=-0.1, z_max=0.
 
     # (z) voxel resolution.
     if z_min > z_max:
-        raise ValueError(
-            "z_min must be smaller than z_max"
-        )
+        raise ValueError("z_min must be smaller than z_max")
     elif z_min == z_max:
-        raise ValueError(
-            "z_min and z_max must be different"
-        )
+        raise ValueError("z_min and z_max must be different")
     else:
         res_z = (z_max - z_min) * 1.01
 
@@ -274,12 +272,10 @@ def check_normalization(cloud, original_area, res_xy = 0.5, z_min=-0.1, z_max=0.
     )
 
     # Area of the voxelated ground slice (n of voxels * area of voxel base)
-    slice_area = voxelated_slice.shape[0] * res_xy ** 2
+    slice_area = voxelated_slice.shape[0] * res_xy**2
 
     if original_area <= 0:
-        raise ValueError(
-            "Original area to compare with must be positive"
-        )
+        raise ValueError("Original area to compare with must be positive")
     elif not 0 < warning_thresh < 1:
         raise ValueError("warning_thresh must be larger than 0 and smaller than 1")
 

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -228,7 +228,7 @@ def normalize_heights(cloud, dtm_points):
 
 
 def check_normalization(
-    cloud, original_area, res_xy=0.5, z_min=-0.1, z_max=0.1, warning_thresh=0.1
+    cloud, original_area, res_xy=1.0, z_min=-0.1, z_max=0.1, warning_thresh=0.1
 ):
     """Compare the area of a slice of points from a point cloud to another area and
     store a warning indicator if difference is greater than a certain threshold. Area
@@ -241,7 +241,7 @@ def check_normalization(
     original_area : float
         Area to compare with.
     res_xy : float
-        (x, y) voxel resolution. Defaults to 0.5 m.
+        (x, y) voxel resolution. Defaults to 1.0 m.
     z_min: float
         The minimum Z value that defines the slice. Defaults to -0.1.
     z_max: float

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -228,7 +228,7 @@ def normalize_heights(cloud, dtm_points):
 
 
 def check_normalization(
-    cloud, original_area, res_xy=1.0, z_min=-0.1, z_max=0.1, warning_thresh=0.1
+    cloud, original_area, res_xy=1.0, z_min=-0.1, z_max=0.15, warning_thresh=0.1
 ):
     """Compare the area of a slice of points from a point cloud to another area and
     store a warning indicator if difference is greater than a certain threshold. Area

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -227,7 +227,7 @@ def normalize_heights(cloud, dtm_points):
 # -----------------------------------------------------------------------------
 
 
-def check_normalization(cloud, n_digits, original_area, z_min=-0.1, z_max=0.1):
+def check_normalization(cloud, original_area, res_xy = 0.5, res_z = 1.0, z_min=-0.1, z_max=0.1, warning_thresh):
     """Compare the area of a slice of points from a point cloud to another area and
     store a warning indicator if difference is greater than 10 %.
 
@@ -235,8 +235,6 @@ def check_normalization(cloud, n_digits, original_area, z_min=-0.1, z_max=0.1):
     ----------
     cloud : numpy.ndarray
         A 2D numpy array storing the point cloud.
-    n_digits : int
-        See dendromatics.voxel.voxelate()
     original_area : float
         Area to compare with.
     z_min: float
@@ -254,20 +252,20 @@ def check_normalization(cloud, n_digits, original_area, z_min=-0.1, z_max=0.1):
 
     # Voxelate the slice and store only cloud_to_vox_ind output for efficiency
     _, _, voxelated_slice = dm.voxelate(
-        ground_slice, 1, 2000, n_digits=n_digits, with_n_points=False, silent=False
+        ground_slice, res_xy, res_z, with_n_points=False, silent=False
     )
 
-    # Area of the voxelated ground slice (number of 1 m2 voxels)
-    slice_area = voxelated_slice.shape[0]
+    # Area of the voxelated ground slice (n of voxels / area of voxel base)
+    slice_area = voxelated_slice.shape[0] / res_xy ** 2
 
-    # Calculate 10 % of the original area
-    ten_percent_of_area = 0.1 * abs(original_area)
+    # Calculate difference in area that breaks the threshold
+    threshold_difference = warning_thresh * abs(original_area)
 
     # Calculate the absolute difference between the two areas
     difference = abs(original_area - slice_area)
 
     # Check if the difference is greater than 10 % of the first number
-    if difference >= ten_percent_of_area:
+    if difference >= threshold_difference:
         area_warning = True
     else:
         area_warning = False

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -220,3 +220,57 @@ def normalize_heights(cloud, dtm_points):
         dtm_points[:, 2][idx_pt_mesh], weights=d, axis=1
     )
     return zs_diff_triples
+
+
+# -----------------------------------------------------------------------------
+# check_normalization()
+# -----------------------------------------------------------------------------
+
+
+def check_normalization(cloud, n_digits, original_area, z_min=-0.1, z_max=0.1):
+    """Compare the area of a slice of points from a point cloud to another area and
+    store a warning indicator if difference is greater than 10 %.
+
+    Parameters
+    ----------
+    cloud : numpy.ndarray
+        A 2D numpy array storing the point cloud.
+    n_digits : int
+        See dendromatics.voxel.voxelate()
+    original_area : float
+        Area to compare with.
+    z_min: float
+        The minimum Z value that defines the slice. Defaults to -0.1.
+    z_max: float
+        The maximum Z value that defines the slice. Defaults to 0.1.
+    
+    Returns
+    -------
+    area_warning : bool
+        True if area difference is greater than 10 %, False if not.
+    """
+    # Select a slice of points from the cloud where Z value is within (z_min, z_max)
+    ground_slice = cloud[(cloud[:, 2] >= z_min) & (cloud[:, 2] <= z_max)]
+
+    # Voxelate the slice and store only cloud_to_vox_ind output for efficiency
+    _, _, voxelated_slice = dm.voxelate(
+                ground_slice, 1, 2000, n_digits = n_digits, with_n_points=False, silent=False
+            )
+    
+    # Area of the voxelated ground slice (number of 1 m2 voxels)
+    slice_area = voxelated_slice.shape[0]
+    
+    # Calculate 10 % of the original area
+    ten_percent_of_area = 0.1 * abs(original_area)
+
+    # Calculate the absolute difference between the two areas
+    difference = abs(original_area - slice_area)
+
+    # Check if the difference is greater than 10 % of the first number
+    if difference >= ten_percent_of_area:
+        area_warning = True
+    else:
+        area_warning = False
+
+    return area_warning
+    

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -243,9 +243,9 @@ def check_normalization(
     res_xy : float
         (x, y) voxel resolution. Defaults to 1.0 m.
     z_min: float
-        The minimum Z value that defines the slice. Defaults to -0.1.
+        The minimum Z value that defines the slice. Defaults to -0.10 m.
     z_max: float
-        The maximum Z value that defines the slice. Defaults to 0.1.
+        The maximum Z value that defines the slice. Defaults to 0.15 m.
     warning_thresh: float
         Threshold area difference. Defaults to 0.1 (10 % difference in area).
 

--- a/src/dendromatics/ground.py
+++ b/src/dendromatics/ground.py
@@ -282,7 +282,7 @@ def check_normalization(cloud, original_area, res_xy = 0.5, z_min=-0.1, z_max=0.
         )
     elif not 0 < warning_thresh < 1:
         raise ValueError("warning_thresh must be larger than 0 and smaller than 1")
-    
+
     else:
         # Calculate difference in area that breaks the threshold
         threshold_difference = warning_thresh * original_area


### PR DESCRIPTION
Added `check_normalization` function. This function slices a normalized point cloud and compares its area vs. a scalar. It's intended use it's to compare the area of a point cloud to the area of a slice of points around ground level from the height-normalized version of the same point cloud. This is useful to check for inconsistencies in the height-normalization