### PR TITLE
Migrate to hatch embedded Ruff linter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,42 +93,41 @@ serve = "python -m http.server --directory docs/_build"
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = [
-  "ruff>=0.0.261",
-  "black>=23.3.0"
-]
+
 [tool.hatch.envs.lint.scripts]
 # static analysis with ruff
-check-static = "ruff check {args:.}"
-check-format = "black --check --diff --color {args:.}"
-fix-static = "ruff --fix {args:.}"
-fix-format = "black {args:.}"
+check-static = "hatch fmt -l --check"
+check-format = "hatch fmt -f --check"
+fix-static = "hatch fmt -l"
+fix-format = "hatch fmt -f"
 check-all = ["check-static", "check-format"]
-fix-all = [
-  "fix-static",
-  "fix-format",
-  "check-all",
-]
+fix-all = ["fix-static", "fix-format", "check-all"]
 
 [tool.ruff]
-select = ["E", "W", "YTT", "NPY", "PYI", "Q", "F", "B", "I"] 
-# TODO Add D, PTH, RET, disabled for now as they collides with intial choices
 target-version = "py310"
 line-length = 88
+
+[tool.ruff.lint]
+# TODO Add D, PTH, RET, disabled for now as they collides with intial choices
+select = ["I001","E", "W", "YTT", "NPY", "PYI", "Q", "F", "B", "I"]
 # TODO: for now we ignore "Line too long error (E501)" 
 # because our comments are too longs
-# Black will take care of the line lenght in code anyway
-ignore = ["E501", 
-# Ignore docstring in public package and module
-  "D100", "D104",
-# Blank line before class
+# code formatting will take care of the line length in code anyway
+ignore = [
+  "E501",
+  # Ignore docstring in public package and module
+  "D100",
+  "D104",
+  # Blank line before class
   "D203",
-# multiline summary second line
+  # multiline summary second line
   "D213",
 # Temporary because relative imports seem to be a design choice
   "F405", "F403"
 ]
 
-[tool.black]
-line-length = 88
-target-version = ["py310"]
+[tool.ruff.lint.isort]
+known-first-party = ["three_d_fin"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"

--- a/src/dendromatics/individualize.py
+++ b/src/dendromatics/individualize.py
@@ -148,9 +148,9 @@ def compute_axes(
             detected_trees[id_valid, 1:4] = pca_out.components_[
                 0, :
             ]  # PCA1 X value | PCA1 Y value | PCA1 Z value
-            detected_trees[id_valid, 4:7] = (
-                centroid  # stem centroid X value | stem centroid Y value | stem centroid Z value
-            )
+            detected_trees[
+                id_valid, 4:7
+            ] = centroid  # stem centroid X value | stem centroid Y value | stem centroid Z value
             detected_trees[id_valid, 7] = diff_z_z0  # Height difference
             detected_trees[id_valid, 8] = np.abs(
                 np.arctan(

--- a/src/dendromatics/sections.py
+++ b/src/dendromatics/sections.py
@@ -912,12 +912,12 @@ def tree_locator(
                         # use BH section diameter as DBH
                         dbh_values[i] = R[i, which_dbh] * 2
 
-                        tree_locations[i, X_field] = X_c[
-                            i, which_dbh
-                        ].flatten()  # use its center x value as x coordinate of tree locator
-                        tree_locations[i, Y_field] = Y_c[
-                            i, which_dbh
-                        ].flatten()  # use its center y value as y coordinate of tree locator
+                        tree_locations[i, X_field] = (
+                            X_c[i, which_dbh].flatten()
+                        )  # use its center x value as x coordinate of tree locator
+                        tree_locations[i, Y_field] = (
+                            Y_c[i, which_dbh].flatten()
+                        )  # use its center y value as y coordinate of tree locator
                         tree_locations[i, Z_field] = tree_vector[i, 7] + dbh
 
                     # If not all of them are valid, then there is no coherence in
@@ -994,12 +994,12 @@ def tree_locator(
                         if filtered_sections.shape[0] == close_to_dbh.shape[0]:
                             dbh_values[i] = R[i, which_dbh] * 2
 
-                            tree_locations[i, X_field] = X_c[
-                                i, which_dbh
-                            ].flatten()  # Their centers are averaged and we keep that value
-                            tree_locations[i, Y_field] = Y_c[
-                                i, which_dbh
-                            ].flatten()  # Their centers are averaged and we keep that value
+                            tree_locations[i, X_field] = (
+                                X_c[i, which_dbh].flatten()
+                            )  # Their centers are averaged and we keep that value
+                            tree_locations[i, Y_field] = (
+                                Y_c[i, which_dbh].flatten()
+                            )  # Their centers are averaged and we keep that value
                             tree_locations[i, Z_field] = tree_vector[i, 7] + dbh
 
                         # Case C
@@ -1016,8 +1016,8 @@ def tree_locator(
                             diff_height = (
                                 dbh - tree_vector[i, 6] + tree_vector[i, 7]
                             )  # Compute the height difference between centroid and BH
-                            dist_centroid_dbh = diff_height / np.cos(
-                                tree_vector[i, 8] * np.pi / 180
+                            dist_centroid_dbh = (
+                                diff_height / np.cos(tree_vector[i, 8] * np.pi / 180)
                             )  # Compute the distance between centroid and axis point at BH.
                             tree_locations[i, :] = (
                                 vector * dist_centroid_dbh + tree_vector[i, 4:7]


### PR DESCRIPTION
Hatch >=1.9.0 embed/declare Ruff as dependency and expose it via a `lint` command. This commit takes advantage of that.