### PR TITLE
Use new built-in hatch test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
         run: hatch run lint:check-all
 
       - name: Run tests
-        run: hatch run cov
+        run: hatch test -c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimum python version is now 3.9.
 
+- Migrate to hatch 1.12+. Make use of `hatch format` and `hatch test` command
 ## [0.4.2] - 2024-03-14
 
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -156,7 +156,7 @@ Install
 
 The list of dependencies is available in the *pyproject.toml* file.
 
-*dendromatics* relies on `hatch <https://github.com/pypa/hatch>`_
+*dendromatics* relies on `hatch <https://github.com/pypa/hatch>` (version > 1.12)
 
 Depending on your version of Python and your OS, you might also need a C/C++ compiler to compile some of the mandatory dependencies (CSF and jakteristics). 
 But in any case you would not have to run the compiler by yourself, the build system will manage dependencies and compilation for you. 
@@ -169,7 +169,7 @@ You can run tests to ensure it works on your computer.
 
 .. code-block:: console
     
-    hatch run cov
+    hatch test -c
 
 It is also possible to build doc locally.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,32 +53,7 @@ Issues = "https://github.com/3DFin/dendromatics/issues"
 [tool.hatch.version]
 path = "src/dendromatics/__about__.py"
 
-[tool.hatch.envs.default]
-dependencies = [
-  "pytest",
-  "pytest-cov",
-  "pytest-randomly",
-]
-[tool.hatch.envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/dendromatics --cov=tests --randomly-seed=1 {args}"
-no-cov = "cov --no-cov {args}"
-
-[[tool.hatch.envs.test.matrix]]
 python = ["39", "310", "311", "312"]
-
-[tool.coverage.run]
-branch = true
-parallel = true
-omit = [
-    "src/dendromatics/__about__.py",
-]
-
-[tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
 
 [tool.hatch.envs.docs]
 detached = true


### PR DESCRIPTION
Starting from hatch 1.12, hatch embed a built-in test command (with coverage). It is equivalent to our current test pipeline thus it's no longer needed.